### PR TITLE
Add explicit provider block to module config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,5 +36,9 @@ module "dcos-forwarding-rule-public-agents" {
     port   = "9090"
   }
 
-  labels = "${var.labels}"
+  labels = "${var.labels}"  
+
+  providers = {
+    google = "google"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ module "dcos-forwarding-rule-public-agents" {
     port   = "9090"
   }
 
-  labels = "${var.labels}"  
+  labels = "${var.labels}"
 
   providers = {
     google = "google"


### PR DESCRIPTION
I was having issues with explicitly passing a provider returning errors about region and/or project not specified. By adding here and in terraform-gcp-compute-forwarding-rule-dcos + terraform-gcp-compute-forwarding-rule-masters, errors went away.